### PR TITLE
Added client-side config

### DIFF
--- a/RollbarPlugin.php
+++ b/RollbarPlugin.php
@@ -65,6 +65,7 @@ class RollbarPlugin extends BasePlugin
     {
         return array(
             'accessToken'      => AttributeType::String,
+            'clientAccessToken' =>  AttributeType::String,
             'reportInDevMode'  => AttributeType::Bool,
         );
     }

--- a/templates/_settings.twig
+++ b/templates/_settings.twig
@@ -11,6 +11,17 @@
     errors:       settings.getErrors('accessToken')
 }) }}
 
+{{ forms.textField({
+    first:        true,
+    label:        "Client Access Token"|t,
+    id:           'clientAccessToken',
+    name:         'clientAccessToken',
+    instructions: "Rollbar project Access Token for client-side."|t,
+    value:        settings.clientAccessToken,
+    autofocus:    true,
+    errors:       settings.getErrors('clientAccessToken')
+}) }}
+
 {{ forms.lightswitchField({
 	label:        "Report in devMode?"|t,
 	id:           'reportInDevMode',

--- a/variables/RollbarVariable.php
+++ b/variables/RollbarVariable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Craft;
+
+class RollbarVariable
+{
+    private $settings;
+
+    public function __construct()
+    {
+        $this->settings = craft()->plugins->getPlugin('rollbar')->getSettings();
+    }
+
+    public function clientAccessToken()
+    {
+        return $this->settings->getAttribute('clientAccessToken');
+    }
+
+    public function reportInDevMode()
+    {
+        return $this->settings->getAttribute('reportInDevMode');
+    }
+}


### PR DESCRIPTION
We found we needed a different API key for JavaScript debugging and also needed to pull out the plugin settings into twig templates.
